### PR TITLE
separation of connectivity check for hydraulic and thermal calculation:

### DIFF
--- a/pandapipes/component_models/abstract_models/base_component.py
+++ b/pandapipes/component_models/abstract_models/base_component.py
@@ -33,7 +33,7 @@ class Component:
         return res_table
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         """
         Function that extracts certain results.
 
@@ -43,10 +43,8 @@ class Component:
         :type options:
         :param branch_results:
         :type branch_results:
-        :param nodes_connected:
-        :type nodes_connected:
-        :param branches_connected:
-        :type branches_connected:
+        :param mode:
+        :type mode:
         :return: No Output.
         """
         raise NotImplementedError

--- a/pandapipes/component_models/abstract_models/branch_models.py
+++ b/pandapipes/component_models/abstract_models/branch_models.py
@@ -159,5 +159,5 @@ class BranchComponent(Component):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         raise NotImplementedError

--- a/pandapipes/component_models/abstract_models/branch_w_internals_models.py
+++ b/pandapipes/component_models/abstract_models/branch_w_internals_models.py
@@ -217,7 +217,7 @@ class BranchWInternalsComponent(BranchComponent):
         return np.array(net[cls.table_name()].sections.values)
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         raise NotImplementedError
 
     @classmethod

--- a/pandapipes/component_models/abstract_models/branch_wo_internals_models.py
+++ b/pandapipes/component_models/abstract_models/branch_wo_internals_models.py
@@ -100,5 +100,5 @@ class BranchWOInternalsComponent(BranchComponent):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         raise NotImplementedError

--- a/pandapipes/component_models/abstract_models/branch_wzerolength_models.py
+++ b/pandapipes/component_models/abstract_models/branch_wzerolength_models.py
@@ -61,7 +61,7 @@ class BranchWZeroLengthComponent(BranchWOInternalsComponent):
         return branch_wzerolength_pit
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         raise NotImplementedError
 
     @classmethod

--- a/pandapipes/component_models/abstract_models/circulation_pump.py
+++ b/pandapipes/component_models/abstract_models/circulation_pump.py
@@ -97,14 +97,12 @@ class CirculationPump(BranchWZeroLengthComponent):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         """
         Function that extracts certain results.
 
-        :param nodes_connected:
-        :type nodes_connected:
-        :param branches_connected:
-        :type branches_connected:
+        :param mode:
+        :type mode:
         :param branch_results:
         :type branch_results:
         :param net: The pandapipes network

--- a/pandapipes/component_models/abstract_models/const_flow_models.py
+++ b/pandapipes/component_models/abstract_models/const_flow_models.py
@@ -51,14 +51,12 @@ class ConstFlow(NodeElementComponent):
         node_pit[index, LOAD] += loads_sum
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         """
         Function that extracts certain results.
 
-        :param nodes_connected:
-        :type nodes_connected:
-        :param branches_connected:
-        :type branches_connected:
+        :param mode:
+        :type mode:
         :param branch_results:
         :type branch_results:
         :param net: The pandapipes network
@@ -74,8 +72,8 @@ class ConstFlow(NodeElementComponent):
         is_loads = loads.in_service.values
         fj, tj = get_lookup(net, "node", "from_to")[cls.get_connected_node_type().table_name()]
         junct_pit = net["_pit"]["node"][fj:tj, :]
-        nodes_connected = get_lookup(net, "node", "active")[fj:tj]
-        is_juncts = np.isin(loads.junction.values, junct_pit[nodes_connected, ELEMENT_IDX])
+        nodes_connected_hyd = get_lookup(net, "node", "active_hydraulics")[fj:tj]
+        is_juncts = np.isin(loads.junction.values, junct_pit[nodes_connected_hyd, ELEMENT_IDX])
 
         is_calc = is_loads & is_juncts
         res_table["mdot_kg_per_s"].values[is_calc] = loads.mdot_kg_per_s.values[is_calc] \

--- a/pandapipes/component_models/abstract_models/node_element_models.py
+++ b/pandapipes/component_models/abstract_models/node_element_models.py
@@ -51,5 +51,5 @@ class NodeElementComponent(Component):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         raise NotImplementedError

--- a/pandapipes/component_models/abstract_models/node_models.py
+++ b/pandapipes/component_models/abstract_models/node_models.py
@@ -66,5 +66,5 @@ class NodeComponent(Component):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         raise NotImplementedError

--- a/pandapipes/component_models/ext_grid_component.py
+++ b/pandapipes/component_models/ext_grid_component.py
@@ -62,20 +62,18 @@ class ExtGrid(NodeElementComponent):
         return ext_grids, press
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         """
         Function that extracts certain results.
 
-        :param nodes_connected:
-        :type nodes_connected:
-        :param branches_connected:
-        :type branches_connected:
         :param branch_results:
         :type branch_results:
         :param net: The pandapipes network
         :type net: pandapipesNet
         :param options:
         :type options:
+        :param mode:
+        :type mode:
         :return: No Output.
         """
         ext_grids = net[cls.table_name()]

--- a/pandapipes/component_models/flow_control_component.py
+++ b/pandapipes/component_models/flow_control_component.py
@@ -5,8 +5,8 @@
 import numpy as np
 from numpy import dtype
 
-from pandapipes.component_models.junction_component import Junction
 from pandapipes.component_models.abstract_models import BranchWZeroLengthComponent, get_fluid
+from pandapipes.component_models.junction_component import Junction
 from pandapipes.idx_branch import D, AREA, TL, JAC_DERIV_DP, JAC_DERIV_DP1, JAC_DERIV_DV, VINIT, \
     RHO, LOAD_VEC_BRANCHES, ELEMENT_IDX
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
@@ -83,24 +83,28 @@ class FlowControlComponent(BranchWZeroLengthComponent):
         branch_component_pit[:, TL] = 0
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         required_results = [
-            ("p_from_bar", "p_from"), ("p_to_bar", "p_to"), ("t_from_k", "temp_from"),
-            ("t_to_k", "temp_to"), ("mdot_to_kg_per_s", "mf_to"), ("mdot_from_kg_per_s", "mf_from"),
-            ("vdot_norm_m3_per_s", "vf"), ("lambda", "lambda"), ("reynolds", "reynolds")
+            ("p_from_bar", "p_from", False), ("p_to_bar", "p_to", False),
+            ("t_from_k", "temp_from", True), ("t_to_k", "temp_to", True),
+            ("mdot_to_kg_per_s", "mf_to", False), ("mdot_from_kg_per_s", "mf_from", False),
+            ("vdot_norm_m3_per_s", "vf", False), ("lambda", "lambda", False),
+            ("reynolds", "reynolds", False)
         ]
 
         if get_fluid(net).is_gas:
             required_results.extend([
-                ("v_from_m_per_s", "v_gas_from"), ("v_to_m_per_s", "v_gas_to"),
-                ("v_mean_m_per_s", "v_gas_mean"), ("normfactor_from", "normfactor_from"),
-                ("normfactor_to", "normfactor_to")
+                ("v_from_m_per_s", "v_gas_from", False),
+                ("v_to_m_per_s", "v_gas_to", False),
+                ("v_mean_m_per_s", "v_gas_mean", False),
+                ("normfactor_from", "normfactor_from", False),
+                ("normfactor_to", "normfactor_to", False)
             ])
         else:
-            required_results.extend([("v_mean_m_per_s", "v_mps")])
+            required_results.extend([("v_mean_m_per_s", "v_mps", False)])
 
         extract_branch_results_without_internals(net, branch_results, required_results,
-                                                 cls.table_name(), branches_connected)
+                                                 cls.table_name(), mode)
 
     @classmethod
     def get_component_input(cls):

--- a/pandapipes/component_models/heat_exchanger_component.py
+++ b/pandapipes/component_models/heat_exchanger_component.py
@@ -60,24 +60,28 @@ class HeatExchanger(BranchWZeroLengthComponent):
         heat_exchanger_pit[:, T_OUT] = 307
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         required_results = [
-            ("p_from_bar", "p_from"), ("p_to_bar", "p_to"), ("t_from_k", "temp_from"),
-            ("t_to_k", "temp_to"), ("mdot_to_kg_per_s", "mf_to"), ("mdot_from_kg_per_s", "mf_from"),
-            ("vdot_norm_m3_per_s", "vf"), ("lambda", "lambda"), ("reynolds", "reynolds")
+            ("p_from_bar", "p_from", False), ("p_to_bar", "p_to", False),
+            ("t_from_k", "temp_from", True), ("t_to_k", "temp_to", True),
+            ("mdot_to_kg_per_s", "mf_to", False), ("mdot_from_kg_per_s", "mf_from", False),
+            ("vdot_norm_m3_per_s", "vf", False), ("lambda", "lambda", False),
+            ("reynolds", "reynolds", False)
         ]
 
         if get_fluid(net).is_gas:
             required_results.extend([
-                ("v_from_m_per_s", "v_gas_from"), ("v_to_m_per_s", "v_gas_to"),
-                ("v_mean_m_per_s", "v_gas_mean"), ("normfactor_from", "normfactor_from"),
-                ("normfactor_to", "normfactor_to")
+                ("v_from_m_per_s", "v_gas_from", False),
+                ("v_to_m_per_s", "v_gas_to", False),
+                ("v_mean_m_per_s", "v_gas_mean", False),
+                ("normfactor_from", "normfactor_from", False),
+                ("normfactor_to", "normfactor_to", False)
             ])
         else:
-            required_results.extend([("v_mean_m_per_s", "v_mps")])
+            required_results.extend([("v_mean_m_per_s", "v_mps", False)])
 
         extract_branch_results_without_internals(net, branch_results, required_results,
-                                                 cls.table_name(), branches_connected)
+                                                 cls.table_name(), mode)
 
     @classmethod
     def calculate_temperature_lift(cls, net, branch_component_pit, node_pit):

--- a/pandapipes/component_models/junction_component.py
+++ b/pandapipes/component_models/junction_component.py
@@ -88,37 +88,44 @@ class Junction(NodeComponent):
         junction_pit[:, ACTIVE_ND] = junctions.in_service.values
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         """
         Function that extracts certain results.
 
-        :param nodes_connected:
-        :type nodes_connected:
-        :param branches_connected:
-        :type branches_connected:
-        :param branch_results:
-        :type branch_results:
+        :param mode:
+        :type mode:
         :param net: The pandapipes network
         :type net: pandapipesNet
         :param options:
         :type options:
+        :param branch_results:
+        :type branch_results:
+        :param mode:
+        :type mode:
         :return: No Output.
         """
         res_table = net["res_" + cls.table_name()]
 
         f, t = get_lookup(net, "node", "from_to")[cls.table_name()]
-        fa, ta = get_lookup(net, "node", "from_to_active")[cls.table_name()]
+        junction_pit = net["_pit"]["node"][f:t, :]
 
-        junction_pit = net["_active_pit"]["node"][fa:ta, :]
-        junctions_active = get_lookup(net, "node", "active")[f:t]
+        if mode in ["hydraulics", "all"]:
+            junctions_connected_hydraulic = get_lookup(net, "node", "active_hydraulics")[f:t]
 
-        if np.any(junction_pit[:, PINIT] < 0):
-            warn(UserWarning('Pipeflow converged, however, the results are physically incorrect '
-                             'as pressure is negative at nodes %s'
-                             % junction_pit[junction_pit[:, PINIT] < 0, ELEMENT_IDX]))
+            if np.any(junction_pit[junctions_connected_hydraulic, PINIT] < 0):
+                warn(UserWarning('Pipeflow converged, however, the results are physically incorrect '
+                                 'as pressure is negative at nodes %s'
+                                 % junction_pit[junction_pit[:, PINIT] < 0, ELEMENT_IDX]))
 
-        res_table["p_bar"].values[junctions_active] = junction_pit[:, PINIT]
-        res_table["t_k"].values[junctions_active] = junction_pit[:, TINIT]
+        #     res_table["p_bar"].values[junctions_connected_hydraulic] = junction_pit[:, PINIT]
+        #     if mode == "hydraulics":
+        #         res_table["t_k"].values[junctions_connected_hydraulic] = junction_pit[:, TINIT]
+        #
+        # if mode in ["heat", "all"]:
+        #     junctions_connected_ht = get_lookup(net, "node", "active_heat_transfer")[f:t]
+        #     res_table["t_k"].values[junctions_connected_ht] = junction_pit[:, TINIT]
+        res_table["p_bar"].values[:] = junction_pit[:, PINIT]
+        res_table["t_k"].values[:] = junction_pit[:, TINIT]
 
     @classmethod
     def get_component_input(cls):

--- a/pandapipes/component_models/pipe_component.py
+++ b/pandapipes/component_models/pipe_component.py
@@ -170,28 +170,32 @@ class Pipe(BranchWInternalsComponent):
         branch_component_pit[:, TL] = 0
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
-        res_nodes_from = [("p_from_bar", "p_from"), ("t_from_k", "temp_from"),
-                          ("mdot_from_kg_per_s", "mf_from")]
-        res_nodes_to = [("p_to_bar", "p_to"), ("t_to_k", "temp_to"), ("mdot_to_kg_per_s", "mf_to")]
-        res_mean = [("vdot_norm_m3_per_s", "vf"), ("lambda", "lambda"), ("reynolds", "reynolds")]
+    def extract_results(cls, net, options, branch_results, mode):
+        res_nodes_from = [("p_from_bar", "p_from", False), ("t_from_k", "temp_from", True),
+                          ("mdot_from_kg_per_s", "mf_from", False)]
+        res_nodes_to = [("p_to_bar", "p_to", False), ("t_to_k", "temp_to", True),
+                        ("mdot_to_kg_per_s", "mf_to", False)]
+        res_mean = [("vdot_norm_m3_per_s", "vf", False), ("lambda", "lambda", False),
+                    ("reynolds", "reynolds", False)]
 
         if get_fluid(net).is_gas:
             res_nodes_from.extend(
-                [("v_from_m_per_s", "v_gas_from"), ("normfactor_from", "normfactor_from")])
-            res_nodes_to.extend([("v_to_m_per_s", "v_gas_to"), ("normfactor_to", "normfactor_to")])
-            res_mean.extend([("v_mean_m_per_s", "v_gas_mean")])
+                [("v_from_m_per_s", "v_gas_from", False),
+                 ("normfactor_from", "normfactor_from", False)])
+            res_nodes_to.extend([("v_to_m_per_s", "v_gas_to", False),
+                                 ("normfactor_to", "normfactor_to", False)])
+            res_mean.extend([("v_mean_m_per_s", "v_gas_mean", False)])
         else:
-            res_mean.extend([("v_mean_m_per_s", "v_mps")])
+            res_mean.extend([("v_mean_m_per_s", "v_mps", False)])
 
         if np.any(cls.get_internal_pipe_number(net) > 1):
             extract_branch_results_with_internals(
                 net, branch_results, cls.table_name(), res_nodes_from, res_nodes_to, res_mean,
-                cls.get_connected_node_type().table_name(), branches_connected)
+                cls.get_connected_node_type().table_name(), mode)
         else:
             required_results = res_nodes_from + res_nodes_to + res_mean
             extract_branch_results_without_internals(net, branch_results, required_results,
-                                                     cls.table_name(), branches_connected)
+                                                     cls.table_name(), mode)
 
     @classmethod
     def get_internal_results(cls, net, pipe):

--- a/pandapipes/component_models/pressure_control_component.py
+++ b/pandapipes/component_models/pressure_control_component.py
@@ -95,14 +95,12 @@ class PressureControlComponent(BranchWZeroLengthComponent):
         branch_component_pit[:, TL] = 0
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         """
         Function that extracts certain results.
 
-        :param nodes_connected:
-        :type nodes_connected:
-        :param branches_connected:
-        :type branches_connected:
+        :param mode:
+        :type mode:
         :param branch_results:
         :type branch_results:
         :param net: The pandapipes network
@@ -112,21 +110,23 @@ class PressureControlComponent(BranchWZeroLengthComponent):
         :return: No Output.
         """
         required_results = [
-            ("p_from_bar", "p_from"), ("p_to_bar", "p_to"), ("t_from_k", "temp_from"),
-            ("t_to_k", "temp_to"), ("mdot_to_kg_per_s", "mf_to"), ("mdot_from_kg_per_s", "mf_from"),
-            ("vdot_norm_m3_per_s", "vf")
+            ("p_from_bar", "p_from", False), ("p_to_bar", "p_to", False),
+            ("t_from_k", "temp_from", True), ("t_to_k", "temp_to"),
+            ("mdot_to_kg_per_s", "mf_to", False), ("mdot_from_kg_per_s", "mf_from", False),
+            ("vdot_norm_m3_per_s", "vf", False)
         ]
 
         if get_fluid(net).is_gas:
             required_results.extend([
-                ("v_from_m_per_s", "v_gas_from"), ("v_to_m_per_s", "v_gas_to"),
-                ("normfactor_from", "normfactor_from"), ("normfactor_to", "normfactor_to")
+                ("v_from_m_per_s", "v_gas_from", False), ("v_to_m_per_s", "v_gas_to", False),
+                ("normfactor_from", "normfactor_from", False),
+                ("normfactor_to", "normfactor_to", False)
             ])
         else:
-            required_results.extend([("v_mean_m_per_s", "v_mps")])
+            required_results.extend([("v_mean_m_per_s", "v_mps", False)])
 
         extract_branch_results_without_internals(net, branch_results, required_results,
-                                                 cls.table_name(), branches_connected)
+                                                 cls.table_name(), mode)
 
         res_table = net["res_" + cls.table_name()]
         f, t = get_lookup(net, "branch", "from_to")[cls.table_name()]

--- a/pandapipes/component_models/pump_component.py
+++ b/pandapipes/component_models/pump_component.py
@@ -111,40 +111,40 @@ class Pump(BranchWZeroLengthComponent):
         branch_component_pit[:, TL] = 0
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         """
         Function that extracts certain results.
 
-        :param nodes_connected:
-        :type nodes_connected:
-        :param branches_connected:
-        :type branches_connected:
         :param branch_results:
         :type branch_results:
         :param net: The pandapipes network
         :type net: pandapipesNet
         :param options:
         :type options:
+        :param mode:
+        :type mode:
         :return: No Output.
         """
         calc_compr_pow = options['calc_compression_power']
 
         required_results = [
-            ("p_from_bar", "p_from"), ("p_to_bar", "p_to"), ("t_from_k", "temp_from"),
-            ("t_to_k", "temp_to"), ("mdot_to_kg_per_s", "mf_to"), ("mdot_from_kg_per_s", "mf_from"),
-            ("vdot_norm_m3_per_s", "vf"), ("deltap_bar", "pl")
+            ("p_from_bar", "p_from", False), ("p_to_bar", "p_to", False),
+            ("t_from_k", "temp_from", True), ("t_to_k", "temp_to", True),
+            ("mdot_to_kg_per_s", "mf_to", False), ("mdot_from_kg_per_s", "mf_from", False),
+            ("vdot_norm_m3_per_s", "vf", False), ("deltap_bar", "pl", False)
         ]
 
         if get_fluid(net).is_gas:
             required_results.extend([
-                ("v_from_m_per_s", "v_gas_from"), ("v_to_m_per_s", "v_gas_to"),
-                ("normfactor_from", "normfactor_from"), ("normfactor_to", "normfactor_to")
+                ("v_from_m_per_s", "v_gas_from", False), ("v_to_m_per_s", "v_gas_to", False),
+                ("normfactor_from", "normfactor_from", False),
+                ("normfactor_to", "normfactor_to", False)
             ])
         else:
-            required_results.extend([("v_mean_m_per_s", "v_mps")])
+            required_results.extend([("v_mean_m_per_s", "v_mps", False)])
 
         extract_branch_results_without_internals(net, branch_results, required_results,
-                                                 cls.table_name(), branches_connected)
+                                                 cls.table_name(), mode)
 
         if calc_compr_pow:
             f, t = get_lookup(net, "branch", "from_to")[cls.table_name()]

--- a/pandapipes/component_models/valve_component.py
+++ b/pandapipes/component_models/valve_component.py
@@ -82,24 +82,27 @@ class Valve(BranchWZeroLengthComponent):
                 ("type", dtype(object))]
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, nodes_connected, branches_connected):
+    def extract_results(cls, net, options, branch_results, mode):
         required_results = [
-            ("p_from_bar", "p_from"), ("p_to_bar", "p_to"), ("t_from_k", "temp_from"),
-            ("t_to_k", "temp_to"), ("mdot_to_kg_per_s", "mf_to"), ("mdot_from_kg_per_s", "mf_from"),
-            ("vdot_norm_m3_per_s", "vf"), ("lambda", "lambda"), ("reynolds", "reynolds")
+            ("p_from_bar", "p_from", False), ("p_to_bar", "p_to", False),
+            ("t_from_k", "temp_from", True), ("t_to_k", "temp_to", True),
+            ("mdot_to_kg_per_s", "mf_to", False), ("mdot_from_kg_per_s", "mf_from", False),
+            ("vdot_norm_m3_per_s", "vf", False), ("lambda", "lambda", False),
+            ("reynolds", "reynolds", False)
         ]
 
         if get_fluid(net).is_gas:
             required_results.extend([
-                ("v_from_m_per_s", "v_gas_from"), ("v_to_m_per_s", "v_gas_to"),
-                ("v_mean_m_per_s", "v_gas_mean"), ("normfactor_from", "normfactor_from"),
-                ("normfactor_to", "normfactor_to")
+                ("v_from_m_per_s", "v_gas_from", False), ("v_to_m_per_s", "v_gas_to", False),
+                ("v_mean_m_per_s", "v_gas_mean", False),
+                ("normfactor_from", "normfactor_from", False),
+                ("normfactor_to", "normfactor_to", False)
             ])
         else:
-            required_results.extend([("v_mean_m_per_s", "v_mps")])
+            required_results.extend([("v_mean_m_per_s", "v_mps", False)])
 
         extract_branch_results_without_internals(net, branch_results, required_results,
-                                                 cls.table_name(), branches_connected)
+                                                 cls.table_name(), mode)
 
     @classmethod
     def get_result_table(cls, net):


### PR DESCRIPTION
- 2 function calls to connectivity check and pit reduction in case of "all" mode
- result extraction from active pit to pit done after both calculations separately
- all result extraction functions (also for all components) must consider that the connectivity lookups now differ between hydraulics and thermal calculation